### PR TITLE
Deploy: Remove unsafe references to facebook/Ax

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -61,36 +61,37 @@ jobs:
       run: |
         bash scripts/publish_site.sh -d
 
-  deploy-test-pypi:
+  # TODO: Temporarily disabled while making changes on fork. Re-enable before merging back into facebook/Ax
+  # deploy-test-pypi:
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v4
-    - name: Fetch all history for all tags and branches
-      run: git fetch --prune --unshallow
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
-    - name: Install dependencies
-      env:
-        ALLOW_BOTORCH_LATEST: true
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-      run: |
-        # use latest BoTorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[dev,mysql,notebook]"
-        pip install wheel
-    - name: Build wheel
-      run: |
-        python setup.py sdist bdist_wheel
-    - name: Deploy to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
-        verbose: true
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Fetch all history for all tags and branches
+  #     run: git fetch --prune --unshallow
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: "3.10"
+  #   - name: Install dependencies
+  #     env:
+  #       ALLOW_BOTORCH_LATEST: true
+  #       ALLOW_LATEST_GPYTORCH_LINOP: true
+  #     run: |
+  #       # use latest BoTorch
+  #       pip install git+https://github.com/cornellius-gp/gpytorch.git
+  #       pip install git+https://github.com/pytorch/botorch.git
+  #       pip install -e ".[dev,mysql,notebook]"
+  #       pip install wheel
+  #   - name: Build wheel
+  #     run: |
+  #       python setup.py sdist bdist_wheel
+  #   - name: Deploy to Test PyPI
+  #     uses: pypa/gh-action-pypi-publish@release/v1
+  #     with:
+  #       user: __token__
+  #       password: ${{ secrets.TEST_PYPI_TOKEN }}
+  #       repository_url: https://test.pypi.org/legacy/
+  #       skip_existing: true
+  #       verbose: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,30 +43,31 @@ jobs:
       run: |
         bash scripts/publish_site.sh -d -v ${{ github.event.release.tag_name }}
 
-  deploy:
+  # TODO: Temporarily disabled while making changes on fork. Re-enable before merging back into facebook/Ax
+  # deploy:
 
-    needs: tests-and-coverage-pinned # only run if test step succeeds
-    runs-on: ubuntu-latest
+  #   needs: tests-and-coverage-pinned # only run if test step succeeds
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
-    - name: Install dependencies
-      run: |
-        # use stable Botorch
-        pip install -e ".[dev,mysql,notebook]"
-        pip install wheel
-    - name: Fetch all history for all tags and branches
-      run: git fetch --prune --unshallow
-    - name: Build wheel
-      run: |
-        python setup.py sdist bdist_wheel
-    - name: Deploy to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
-        verbose: true
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: "3.10"
+  #   - name: Install dependencies
+  #     run: |
+  #       # use stable Botorch
+  #       pip install -e ".[dev,mysql,notebook]"
+  #       pip install wheel
+  #   - name: Fetch all history for all tags and branches
+  #     run: git fetch --prune --unshallow
+  #   - name: Build wheel
+  #     run: |
+  #       python setup.py sdist bdist_wheel
+  #   - name: Deploy to PyPI
+  #     uses: pypa/gh-action-pypi-publish@release/v1
+  #     with:
+  #       user: __token__
+  #       password: ${{ secrets.PYPI_TOKEN }}
+  #       verbose: true

--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -58,11 +58,13 @@ if [[ $DOCUSAURUS_BOT == true ]]; then
   echo "machine github.com login docusaurus-bot password ${DOCUSAURUS_PUBLISH_TOKEN}" > ~/.netrc
 
   # Clone both main & gh-pages branches
-  git clone https://docusaurus-bot@github.com/facebook/Ax.git Ax-main
-  git clone --branch gh-pages https://docusaurus-bot@github.com/facebook/Ax.git Ax-gh-pages
+  # TODO: Temporarily changed while making changes on fork. Revert before merging back into facebook/Ax
+  git clone https://docusaurus-bot@github.com/CristianLara/Ax.git Ax-main
+  git clone --branch gh-pages https://docusaurus-bot@github.com/CristianLara/Ax.git Ax-gh-pages
 else
-  git clone https://github.com/facebook/Ax.git Ax-main
-  git clone --branch gh-pages https://github.com/facebook/Ax.git Ax-gh-pages
+# TODO: Temporarily changed while making changes on fork. Revert before merging back into facebook/Ax
+  git clone https://github.com/CristianLara/Ax.git Ax-main
+  git clone --branch gh-pages https://github.com/CristianLara/Ax.git Ax-gh-pages
 fi
 
 # A few notes about the script below:
@@ -143,7 +145,8 @@ if [[ $VERSION == false ]]; then
   git init -b main
   git add --all
   git commit -m 'Update latest version of site'
-  git push --force https://github.com/facebook/Ax.git main:gh-pages
+  # TODO: Temporarily changed while making changes on fork. Revert before merging back into facebook/Ax
+  git push --force https://github.com/CristianLara/Ax.git main:gh-pages
 
 else
   echo "-----------------------------------------"
@@ -220,7 +223,8 @@ else
   git init -b main
   git add --all
   git commit -m "Publish version ${VERSION} of site"
-  git push --force https://github.com/facebook/Ax.git main:gh-pages
+  # TODO: Temporarily changed while making changes on fork. Revert before merging back into facebook/Ax
+  git push --force https://github.com/CristianLara/Ax.git main:gh-pages
 
 fi
 

--- a/scripts/versions.js
+++ b/scripts/versions.js
@@ -74,7 +74,8 @@ function Versions(props) {
                 </td>
                 <td>
                   <code>
-                    pip3 install git+ssh://git@github.com/facebook/Ax.git
+                    {/* # TODO: Temporarily changed while making changes on fork. Revert before merging back into facebook/Ax */}
+                    pip3 install git+ssh://git@github.com/CristianLara/Ax.git
                   </code>
                 </td>
                 <td>


### PR DESCRIPTION
We're going to be working in this fork for a while so let's sanitize the github actions so we can actually use them to build the new website.

Changes include:
1. Comment out steps for deploying to PyPI
2. Change references in our workflows from `facebook/Ax` to `CristianLara/Ax`. The main offender was a section of `scripts/publish_site.sh` which does a `git push --force`.