### PR TITLE
Deploy: Allow triggering deploys manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@
 name: Deploy
 
 on:
+  # TODO: Temporarily allow running manually while making changes on fork. Disable before merging back into facebook/Ax
+  workflow_dispatch:
   release:
     types: [created]
 


### PR DESCRIPTION
So that we don't have to create fake releases just to re-deploy the website while testing