### PR TITLE
Actions: Publish Website use github actions bot

### DIFF
--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -63,8 +63,8 @@ if [[ $DOCUSAURUS_BOT == true ]]; then
   git clone --branch gh-pages https://docusaurus-bot@github.com/CristianLara/Ax.git Ax-gh-pages
 else
 # TODO: Temporarily changed while making changes on fork. Revert before merging back into facebook/Ax
-  git config --global user.name "${{ github.actor }}"
-  git config --global user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+  git config --global user.name "github-actions[bot]"
+  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
   git clone https://github.com/CristianLara/Ax.git Ax-main
   git clone --branch gh-pages https://github.com/CristianLara/Ax.git Ax-gh-pages
 fi


### PR DESCRIPTION
The previous code attempted to create these same strings using the actions `github` environment variable but these are not available in the shell script. It may be possible to pass in the variable but we can just be explicit here instead that this is intended to be done by the bot.

The name and email are provided by the official actions/checkout@v4 documentation: https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token