### PR TITLE
Tutorials: Render errors

### DIFF
--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -28,6 +28,7 @@ TUTORIALS_DIR = DOCS_DIR.joinpath("tutorials")
 # text/plain if text/html is not working. The below priorities help ensure the output in
 # the MDX file shows the best representation of the cell output.
 priorities = [
+    "error",
     "text/markdown",
     "image/png",  # matplotlib output.
     "application/vnd.jupyter.widget-view+json",  # tqdm progress bars.
@@ -854,7 +855,7 @@ def aggregate_output_types(cell_outputs: List[NotebookNode]) -> CELL_OUTPUTS_TO_
         data = (
             cell_output["data"][prioritized_data_dtype]
             if "data" in cell_output
-            else cell_output["text"]
+            else cell_output["text"] if "text" in cell_output else cell_output["evalue"]
         )
         bokeh_check = "bokeh" in prioritized_data_dtype or (
             prioritized_data_dtype == "text/html" and "Bokeh Application" in data
@@ -877,7 +878,7 @@ def aggregate_output_types(cell_outputs: List[NotebookNode]) -> CELL_OUTPUTS_TO_
                 cell_outputs_to_process,
                 i,
             )
-        plain_check = prioritized_data_dtype in ["text/plain", "stream"]
+        plain_check = prioritized_data_dtype in ["text/plain", "stream", "error"]
         if plain_check:
             aggregate_plain_output(
                 prioritized_data_dtype,

--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -326,12 +326,14 @@ def handle_markdown_cell(
     # Skip - Our images are base64 encoded, so we don't need to copy them to the docs folder.
     # markdown = handle_images_found_in_markdown(markdown, new_img_dir, lib_dir)
 
-    # We will attempt to handle inline style attributes written in HTML by converting
-    # them to something React can consume.
-    markdown = transform_style_attributes(markdown)
-
     markdown = sanitize_mdx(markdown)
     mdx = mdformat.text(markdown, options={"wrap": 88}, extensions={"myst"})
+
+    # We will attempt to handle inline style attributes written in HTML by converting
+    # them to something React can consume. This has to be done after the mdformat.text() step
+    # since mdformat complains about the converted styles.
+    mdx = transform_style_attributes(mdx)
+
     return f"{mdx}\n"
 
 


### PR DESCRIPTION
We can handle errors the same way we handle other plain text.

Ideally we won't be deploying errors in our live tutorials but I currently have some and it's handy to have support, especially when it's trivial to add to the script. Currently our build scripts are set up to give up on tutorial generation if an error is encountered while running the tutorials in CI.

Rendering errors surfaced a bug in the script where mdformat doesn't like our JSX if it contains the transformed style attributes. It would think the "html" is invalid and add a backslash to i guess try and escape it?

This was a confusing bug, thankfully someone else ran into this before and offered some guidance: https://github.com/executablebooks/mdformat/issues/388#issuecomment-1483371326

<img width="1271" alt="image" src="https://github.com/user-attachments/assets/1098c28b-c31d-41cb-8d3e-7b21b3e6801c">

⬇️ ⬇️ ⬇️  

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/01eb8c88-bb50-4c13-9133-c4a5df6f596d">
