### PR TITLE
Docs: Use ReadTheDocs for API reference 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,10 @@ build:
 
 python:
   install:
-    - requirements: sphinx/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev
 
 sphinx:
   configuration: sphinx/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: "2"
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: sphinx/requirements.txt
+
+sphinx:
+  configuration: sphinx/source/conf.py

--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -13,7 +13,7 @@ usage() {
   echo "Build Ax documentation. Must be executed from root of Ax repository."
   echo ""
   echo "  -b   Build static version of documentation (otherwise start server)."
-  echo "  -o   Only Docusaurus (skip Sphinx, tutorials). Useful when just make change to Docusaurus settings."
+  echo "  -o   Only Docusaurus (skip tutorials). Useful when just make change to Docusaurus settings."
   echo "  -t   Execute tutorials (instead of just converting)."
   echo "  -r   Convert backtick-quoted class or function names in .md files into links to API documentation."
   echo ""
@@ -86,13 +86,3 @@ else
   yarn start
 fi
 cd .. || exit
-
-if [[ $ONLY_DOCUSAURUS == false ]]; then
-  # generate Sphinx documentation
-  echo "-----------------------------------"
-  echo "Generating API reference via Sphinx"
-  echo "-----------------------------------"
-  cd sphinx || exit
-  make dirhtml
-  cd .. || exit
-fi

--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -204,7 +204,7 @@ else
   # Set Docusaurus version with exact version & build
   yarn run version "${VERSION}"
   cd .. || exit
-  # Only run Docusaurus (skip tutorial build & Sphinx)
+  # Only run Docusaurus (skip tutorial build)
   ./scripts/make_docs.sh -b -o
   rm -rf website/build/Ax/docs/next  # don't need this
   rm -rf website/build/Ax/docs/stable  # or this

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==7.1.2
+sphinx-rtd-theme==1.3.0rc1

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,2 +1,0 @@
-sphinx==7.1.2
-sphinx-rtd-theme==1.3.0rc1

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -79,7 +79,7 @@ module.exports={
           "position": "left"
         },
         {
-          "href": "/Ax/api/",
+          "href": "https://ax.readthedocs.io/en/latest/index.html",
           "label": "API",
           "position": "left",
           "target": "_blank",


### PR DESCRIPTION
No longer build sphinx docs ourselves as part of our doc build process. Instead ReadTheDocs will auto build and host Sphinx when it detects changes to our repo. We link to ReadTheDocs (https://ax.readthedocs.io/en/latest/index.html) from our docusaurus page.

We can still build the sphinx docs locally for testing via the usual way: `cd sphinx && make dirhtml`

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/691f048e-b61f-4609-bc02-c13218d51145">

⬇️⬇️⬇️⬇️ leads to ⬇️⬇️⬇️⬇️⬇️

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/0d1c578a-167f-421d-9bef-4fa3d9293548">
