### PR TITLE
[GHA] Always create new docusaurus version, only keep latest patch fo…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,39 +22,8 @@ jobs:
       pinned_botorch: true
     secrets: inherit
 
-  check-versions:
-    needs: tests-and-coverage-pinned
-    name: Check if major or minor version changed
-    runs-on: ubuntu-latest
-    outputs:
-      major_minor_changed: ${{ steps.compare.outputs.major_minor_changed }}
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        fetch-tags: true
-        ref: ${{ github.sha }}
-    - name: Check if major or minor version changed
-      id: compare
-      run: |
-        git fetch --tags --force
-        previous_version=$(git describe --tags --abbrev=0 ${{ github.event.release.tag_name }}^)
-        prev=$(cut -d '.' -f 1-2 <<< $previous_version) # remove patch number
-        prev=${prev#v}                                  # remove optional "v" prefix
-        next=$(cut -d '.' -f 1-2 <<< ${{ github.event.release.tag_name }})
-        next=${next#v}
-
-        echo "Updating from version $previous_version to ${{ github.event.release.tag_name }}"
-        if [[ "$prev" == "$next" ]]; then
-          echo "::warning::Major/Minor version was not changed. Skipping website & docs generation step."
-        else
-          echo major_minor_changed=true >> $GITHUB_OUTPUT
-        fi
-
   version-and-publish-website:
-    needs: check-versions
     name: Version and Publish website
-    if: ${{ needs.check-versions.outputs.major_minor_changed == 'true' }}
     uses: ./.github/workflows/publish_website.yml
     with:
       new_version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -76,6 +76,27 @@ jobs:
       run: |
         python scripts/run_tutorials.py -w $(pwd)
     - if: ${{ inputs.new_version && !inputs.dry_run }}
+      name: Delete existing similar versions from Docusaurus
+      run: |
+        # Delete existing versions for same Major and Minor version numbers.
+        # We do this to keep only the latest patch for a given major/minor version.
+        MAJOR_MINOR_VERSION=$(cut -d '.' -f 1-2 <<< ${{ inputs.new_version }}) # remove patch number
+        MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION#v}                           # remove optional "v" prefix
+        for dir in website/versioned_docs/version-$MAJOR_MINOR_VERSION.*; do
+            if [ -d "$dir" ]; then
+                OLD_VERSION=$(basename "$dir" | sed 's/^version-//') # remove "version-" prefix from the directory name
+                echo "Deleting older version $OLD_VERSION with the same major and minor version numbers as $NEW_VERSION"
+                # Delete version from the three locations Docusaurus uses:
+                #   - versioned_docs/version-X.Y.Z/
+                #   - versioned_sidebars/version-X.Y.Z-sidebars.json
+                #   - versions.json
+                # https://docusaurus.io/docs/versioning#deleting-an-existing-version
+                rm -rf "$dir"
+                rm "website/versioned_sidebars/version-$OLD_VERSION-sidebars.json"
+                sed -i "/\"$OLD_VERSION\"/d" website/versions.json
+            fi
+        done
+    - if: ${{ inputs.new_version && !inputs.dry_run }}
       name: Create new docusaurus version
       run: |
         python3 scripts/convert_ipynb_to_mdx.py --clean


### PR DESCRIPTION
…r given major.minor version

Before this change we would only create new versions in docusaurus if the major or minor version changed, but this prevents the website from showing documentation changes bundled with patch releases.

The change here is to always create a new version in docusaurus, but ensure that for a given X.Y major.minor version we only track the latest patch. We accomplish this by deleting versions we previously created in docusaurus if they only differ by the patch version (i.e. `Z` in `X.Y.Z`)

While Docusaurus provides an npm command to easily create new versions, deleting them has to be done manually using the instructions provided here: https://docusaurus.io/docs/versioning#deleting-an-existing-version